### PR TITLE
👷 ci: update Ubuntu runner to 24.04

### DIFF
--- a/.github/workflows/rcalc-test.yml
+++ b/.github/workflows/rcalc-test.yml
@@ -14,12 +14,10 @@ env:
 
 jobs:
   test-rcalc:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Install Dependencies
-        run: sudo apt update && sudo apt install -y libtinfo5
       - name: Update rust toolchain
         run: rustup update
       - name: Install LLVM and Clang


### PR DESCRIPTION
## Summary

- run the test workflow on the supported Ubuntu 24.04 hosted image
- remove the legacy `libtinfo5` bootstrap, which is unavailable in Ubuntu 24.04
- keep the tested LLVM 21.1 / inkwell `llvm21-1` pairing and the current `actions/checkout@v7` / `actions/cache@v6` actions

## Why #193 is blocked

[#193](https://github.com/ShigureLab/rcalc/pull/193) only changes the runner from Ubuntu 22.04 to 24.04. Its [failing job](https://github.com/ShigureLab/rcalc/actions/runs/25730778074/job/75555177914) reaches the Ubuntu 24.04 image and completes checkout, then exits with apt status 100 because `libtinfo5` cannot be located. Rustup, LLVM installation, linking, and tests never run, so the observed failure is package availability rather than a Rust, linker/runtime, Actions, or runner-image-EOL failure.

The manual `libtinfo5` install was added for an older prebuilt LLVM setup. rcalc now installs LLVM 21 from apt.llvm.org's native Noble repository; its `llvm-21-dev` package uses Noble's current ncurses development dependency instead. Removing the obsolete prerequisite lets the existing LLVM 21.1 / inkwell 0.9.0 configuration run directly on Ubuntu 24.04.

This incorporates #193's runner update together with its missing compatibility fix. Once merged, #193's one-line change is redundant and can be closed rather than merged separately.

## Validation

- `actionlint .github/workflows/rcalc-test.yml`
- `cargo fmt --all -- --check`
- `cargo test --release` — 20 passed
- `LLVM_SYS_211_PREFIX=/opt/homebrew/opt/llvm@21 cargo test --features="jit" --release` with LLVM 21.1.8 — 24 passed
- all six workflow E2E assertions passed locally with and without JIT
- apt.llvm.org currently publishes the LLVM 21 Noble package set used by this workflow
- TheDan64/inkwell's current LLVM 21.1 job also succeeds on an Ubuntu 24.04 hosted runner with the `llvm21-1` feature

The repository has no Dockerfile or other container build definition to update. The pull-request workflow run is the authoritative Ubuntu 24.04 end-to-end validation.
